### PR TITLE
MIDIPacketNext update & minor code refactor/tweaks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,23 +1,30 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
+	
     name: "WebMIDIKit",
-    products: [
+	
+	platforms: [.macOS(.v10_11)],
+	
+	products: [
         .library(
             name: "WebMIDIKit",
             targets: ["WebMIDIKit"]),
     ],
-    dependencies: [
+	
+	dependencies: [
     ],
-    targets: [
+	
+	targets: [
         .target(
             name: "WebMIDIKit",
             dependencies: []),
         .testTarget(
             name: "WebMIDIKitTests",
-            dependencies: []),
+            dependencies: ["WebMIDIKit"]),
     ]
+	
 )

--- a/README.md
+++ b/README.md
@@ -26,18 +26,10 @@ Also note that WebMIDIKit adds some APIs which aren't a part of the WebMIDI stan
 
 ### Installation
 
-Use Swift Package Manager.
+Use Swift Package Manager. Add the following `.Package` entry into your dependencies.
 
-```
-import PackageDescription
-
-let package = Package(
-    name: "WebMIDIKitDemo",
-    dependencies: [
-      .Package(url: "https://github.com/adamnemecek/WebMIDIKit.git", majorVersion: 1)
-    ]
-
-)
+```swift
+.Package(url: "https://github.com/adamnemecek/webmidikit", from: "1.0.0")
 ```
 
 ### Check out the [sample project](https://github.com/adamnemecek/WebMIDIKitDemo).
@@ -121,16 +113,7 @@ for (id, port) in midi.inputs {
 Use Swift Package Manager. Add the following `.Package` entry into your dependencies.
 
 ```swift
-import PackageDescription
-
-let packet = Package(
-	name: "...",
-	target: [],
-	dependencies: [
-		// ...
-		.Package(url:"https://github.com/adamnemecek/webmidikit", version: 1)
-	]
-)
+.Package(url: "https://github.com/adamnemecek/webmidikit", from: "1.0.0")
 ```
 
  If you are having any build issues, look at the sample project [sample project](https://github.com/adamnemecek/WebMIDIKitDemo).

--- a/Sources/WebMIDIKit/Enums.swift
+++ b/Sources/WebMIDIKit/Enums.swift
@@ -83,7 +83,7 @@ internal enum MIDIEndpointNotificationType {
         case .msgObjectRemoved:
             self = .removed
         default:
-            fatalError("unpexpected")
+            fatalError("unexpected")
         }
     }
 }

--- a/Sources/WebMIDIKit/Extensions.swift
+++ b/Sources/WebMIDIKit/Extensions.swift
@@ -27,13 +27,9 @@ extension MIDIObjectType : CustomStringConvertible {
         case .externalEntity: return "externalEntity"
         case .externalSource: return "externalSource"
         case .externalDestination: return "externalDestination"
-        }
+		}
     }
+	public var debugDescription: String {
+		return "\(self.self)(\(description))"
+	}
 }
-
-extension CustomStringConvertible {
-    public var debugDescription: String {
-        return "\(self.self)(\(description))"
-    }
-}
-

--- a/Sources/WebMIDIKit/MIDIClient.swift
+++ b/Sources/WebMIDIKit/MIDIClient.swift
@@ -15,7 +15,7 @@ internal extension Notification.Name {
 
 /// Kind of like a session, context or handle, it doesn't really do anything
 /// besides being passed around. Also dispatches notifications.
-internal final class MIDIClient : Equatable, Comparable, Hashable {
+internal final class MIDIClient {
     let ref: MIDIClientRef
 
     internal init() {
@@ -27,18 +27,22 @@ internal final class MIDIClient : Equatable, Comparable, Hashable {
     deinit {
         OSAssert(MIDIClientDispose(ref))
     }
+}
 
-    var hashValue: Int {
-        return ref.hashValue
-    }
+extension MIDIClient : Equatable, Comparable {
+	static func ==(lhs: MIDIClient, rhs: MIDIClient) -> Bool {
+		return lhs.ref == rhs.ref
+	}
 
-    static func ==(lhs: MIDIClient, rhs: MIDIClient) -> Bool {
-        return lhs.ref == rhs.ref
-    }
+	static func <(lhs: MIDIClient, rhs: MIDIClient) -> Bool {
+		return lhs.ref < rhs.ref
+	}
+}
 
-    static func <(lhs: MIDIClient, rhs: MIDIClient) -> Bool {
-        return lhs.ref < rhs.ref
-    }
+extension MIDIClient : Hashable {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(ref.hashValue)
+	}
 }
 
 /// called when an endpoint is added or removed

--- a/Sources/WebMIDIKit/MIDIEndpoint.swift
+++ b/Sources/WebMIDIKit/MIDIEndpoint.swift
@@ -12,7 +12,7 @@ import CoreMIDI
 // you can think of this as the HW input/output or virtual endpoint
 //
 
-internal class MIDIEndpoint : Equatable, Comparable, Hashable {
+internal class MIDIEndpoint {
     final let ref: MIDIEndpointRef
 
     init(ref: MIDIEndpointRef) {
@@ -22,18 +22,6 @@ internal class MIDIEndpoint : Equatable, Comparable, Hashable {
     internal init(notification n: MIDIObjectAddRemoveNotification) {
         assert(MIDIPortType(n.childType) == MIDIEndpoint(ref: n.child).type)
         self.ref = n.child
-    }
-
-    static func ==(lhs: MIDIEndpoint, rhs: MIDIEndpoint) -> Bool {
-        return lhs.id == rhs.id
-    }
-
-    static func <(lhs: MIDIEndpoint, rhs: MIDIEndpoint) -> Bool {
-        return lhs.id < rhs.id
-    }
-
-    final var hashValue: Int {
-        return id
     }
 
     final var id: Int {
@@ -76,6 +64,22 @@ internal class MIDIEndpoint : Equatable, Comparable, Hashable {
     final private subscript(int property: CFString) -> Int {
         return MIDIObjectGetIntProperty(ref: ref, property: property)
     }
+}
+
+extension MIDIEndpoint: Equatable, Comparable {
+	static func ==(lhs: MIDIEndpoint, rhs: MIDIEndpoint) -> Bool {
+		return lhs.id == rhs.id
+	}
+
+	static func <(lhs: MIDIEndpoint, rhs: MIDIEndpoint) -> Bool {
+		return lhs.id < rhs.id
+	}
+}
+
+extension MIDIEndpoint : Hashable {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(id)
+	}
 }
 
 @inline(__always) fileprivate

--- a/Sources/WebMIDIKit/MIDIPacketList.swift
+++ b/Sources/WebMIDIKit/MIDIPacketList.swift
@@ -14,8 +14,8 @@ extension MIDIPacketList {
     internal mutating func send(to output: MIDIOutput, offset: Double? = nil) {
 
         _ = offset.map {
-
-            let current = AudioGetCurrentHostTime()
+			// NOTE: AudioGetCurrentHostTime() CoreAudio method is only available on macOS
+			let current = AudioGetCurrentHostTime()
             let _offset = AudioConvertNanosToHostTime(UInt64($0 * 1000000))
 
             let ts = current + _offset
@@ -53,7 +53,7 @@ extension MIDIPacket {
 
         timeStamp = timestamp
 
-        var d = Data(data)
+        let d = Data(data)
         length = UInt16(d.count)
 
         /// write out bytes to data
@@ -91,7 +91,7 @@ extension MIDIPacketList: Sequence {
 
         return AnyIterator {
             defer {
-                p = MIDIPacketNext(&p).pointee
+				p = withUnsafePointer(to: &p) { MIDIPacketNext($0).pointee }
             }
 
             return i.next().map { _ in .init(packet: &p) }

--- a/Sources/WebMIDIKit/MIDIPort.swift
+++ b/Sources/WebMIDIKit/MIDIPort.swift
@@ -10,7 +10,7 @@ import CoreMIDI
 
 /// This interface represents a MIDI input or output port.
 /// See [spec](https://www.w3.org/TR/webmidi/#midiport-interface)
-public class MIDIPort : Equatable, Comparable, Hashable, CustomStringConvertible {
+public class MIDIPort {
 
     /// A unique ID of the port. This can be used by developers to remember ports
     /// the user has chosen for their application. This is maintained across
@@ -97,31 +97,7 @@ public class MIDIPort : Equatable, Comparable, Hashable, CustomStringConvertible
         onStateChange?(self)
         onStateChange = nil
     }
-
-    public static func ==(lhs: MIDIPort, rhs: MIDIPort) -> Bool {
-        return lhs.endpoint == rhs.endpoint
-    }
-
-    public static func <(lhs: MIDIPort, rhs: MIDIPort) -> Bool {
-        return lhs.endpoint < rhs.endpoint
-    }
-
-    public final var hashValue: Int {
-        return endpoint.hashValue
-    }
-
-    public final var description: String {
-        return "MIDIPort: \(type), \(name) by \(manufacturer), connection: \(connection) (id: \(id))"
-    }
-
-//    public func encode(to encoder: Encoder) throws {
-//        fatalError()
-//    }
-//
-//    public required init(from decoder: Decoder) throws {
-//        fatalError()
-//    }
-
+	
     internal private(set) final var ref: MIDIPortRef
 
     internal private(set) final weak var client: MIDIClient!
@@ -132,6 +108,28 @@ public class MIDIPort : Equatable, Comparable, Hashable, CustomStringConvertible
         self.endpoint = endpoint
         self.ref = 0
     }
+}
+
+extension MIDIPort : CustomStringConvertible {
+	public final var description: String {
+		return "MIDIPort: \(type), \(name) by \(manufacturer), connection: \(connection) (id: \(id))"
+	}
+}
+
+extension MIDIPort : Equatable, Comparable {
+	public static func ==(lhs: MIDIPort, rhs: MIDIPort) -> Bool {
+		return lhs.endpoint == rhs.endpoint
+	}
+
+	public static func <(lhs: MIDIPort, rhs: MIDIPort) -> Bool {
+		return lhs.endpoint < rhs.endpoint
+	}
+}
+
+extension MIDIPort : Hashable {
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(endpoint.hashValue)
+	}
 }
 
 //func sequence(first: UnsafePointer<MIDIPacketList>) -> AnyIterator<MIDIEvent> {

--- a/Sources/WebMIDIKit/MIDIPortMap.swift
+++ b/Sources/WebMIDIKit/MIDIPortMap.swift
@@ -8,7 +8,7 @@
 
 import CoreMIDI
 
-public class MIDIPortMap<Value: MIDIPort> : Collection, CustomStringConvertible, CustomDebugStringConvertible {
+public class MIDIPortMap<Value: MIDIPort> : Collection {
     public typealias Key = Int
     public typealias Index = Dictionary<Key, Value>.Index
 
@@ -36,11 +36,7 @@ public class MIDIPortMap<Value: MIDIPort> : Collection, CustomStringConvertible,
     public final func index(after i: Index) -> Index {
         return _content.index(after: i)
     }
-
-    public final var description: String {
-        return dump(_content).description
-    }
-
+	
     public func port(with name: String) -> Value? {
         return _content.first { $0.value.displayName == name }?.value
     }
@@ -113,6 +109,14 @@ public final class MIDIOutputMap : MIDIPortMap<MIDIOutput> {
     }
 }
 
+extension MIDIPortMap: CustomStringConvertible, CustomDebugStringConvertible {
+	public final var description: String {
+		return dump(_content).description
+	}
+	public var debugDescription: String {
+		return "\(self.self)(\(description))"
+	}
+}
 
 @inline(__always) fileprivate
 func MIDISources() -> [MIDIEndpoint] {

--- a/Sources/WebMIDIKit/WebMIDIKit.swift
+++ b/Sources/WebMIDIKit/WebMIDIKit.swift
@@ -10,7 +10,7 @@ import CoreMIDI
 import Foundation
 
 /// https://www.w3.org/TR/webmidi/#midiaccess-interface
-public final class MIDIAccess : CustomStringConvertible, CustomDebugStringConvertible {
+public final class MIDIAccess {
 
     public let inputs: MIDIInputMap
     public let outputs: MIDIOutputMap
@@ -42,10 +42,6 @@ public final class MIDIAccess : CustomStringConvertible, CustomDebugStringConver
 
     deinit {
         _observer.map(NotificationCenter.default.removeObserver)
-    }
-
-    public var description: String {
-        return "inputs: \(inputs)\n, output: \(outputs)"
     }
 
     private func _notification(endpoint: MIDIEndpoint, type: MIDIEndpointNotificationType) -> MIDIPort? {
@@ -95,6 +91,16 @@ public final class MIDIAccess : CustomStringConvertible, CustomDebugStringConver
     private var _observer: NSObjectProtocol? = nil
 
 }
+
+extension MIDIAccess : CustomStringConvertible, CustomDebugStringConvertible {
+	public var description: String {
+		return "inputs: \(inputs)\n, output: \(outputs)"
+	}
+	public var debugDescription: String {
+		return "\(self.self)(\(description))"
+	}
+}
+
 
 fileprivate extension NotificationCenter {
     final func observeMIDIEndpoints(_ callback: @escaping (MIDIEndpoint, MIDIEndpointNotificationType) -> ()) -> NSObjectProtocol {


### PR DESCRIPTION
While I updated the MIDIPacketNext code, I had to update a few other things to get the library to compile.

I upped the Package swift version to 5.3 which allows using the `platforms` parameter, which was needed because `MIDIClientCreateWithBlock` and `MIDIInputPortCreateWithBlock` require macOS 10.11 minimum.

It's worth noting that as-is, this is a macOS-only library and will not build on other platforms such as iOS because it uses a couple API calls that are macOS-only: `AudioGetCurrentHostTime` and `AudioConvertNanosToHostTime`.

Cheers.