### PR TITLE
Improve Xcode 12+ compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Closes #31 

When trying to "Add Package" from e.g. an Xcode macOS app project, this package does resolve, but SwiftPM complains about the tools-version not being set.

Updating this to (with whitespace, which is new ⚠️) ` 5.6` works; but 5.5 may be good enough, too.

This increases the minimum required Swift version, though. Not sure if you're ok with this @adamnemecek?